### PR TITLE
Night Time Clear (sunny) and Partly Cloudy Updates

### DIFF
--- a/sensor.yaml
+++ b/sensor.yaml
@@ -63,9 +63,9 @@ template:
             {% endif %}
           weather_condition_0: >
             {% set cond0 = state_attr('weather.hourly', 'forecast')[0].condition %}
-            {% set next_setting = as_timestampstate_attr('sun.sun', 'next_setting')) %}
-            {% set next_rising = as_timestampstate_attr('sun.sun', 'next_rising')) %}
-            {% set cond0_time = as_timestampstate_attr('weather.hourly', 'forecast')[0].datetime) %}
+            {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
+            {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
+            {% set cond0_time = as_timestamp(state_attr('weather.hourly', 'forecast')[0].datetime) %}
             {% if cond0_time > next_setting && cond0_time < next_rising %}
                 {% if cond0 == 'sunny' %} night {% elif cond0 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond0 }} {% endif %}
             {% else %}
@@ -77,9 +77,9 @@ template:
             {{ as_timestamp(state_attr('weather.hourly', 'forecast')[0].datetime) | timestamp_custom('%I') | int }} {{ as_timestamp(state_attr('weather.hourly', 'forecast')[0].datetime) | timestamp_custom('%p') }}
           weather_condition_1: >
             {% set cond1 = state_attr('weather.hourly', 'forecast')[1].condition %}
-            {% set next_setting = as_timestampstate_attr('sun.sun', 'next_setting')) %}
-            {% set next_rising = as_timestampstate_attr('sun.sun', 'next_rising')) %}
-            {% set cond1_time = as_timestampstate_attr('weather.hourly', 'forecast')[1].datetime) %}
+            {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
+            {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
+            {% set cond1_time = as_timestamp(state_attr('weather.hourly', 'forecast')[1].datetime) %}
             {% if cond1_time > next_setting && cond1_time < next_rising %}
                 {% if cond1 == 'sunny' %} night {% elif cond1 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond1 }} {% endif %}
             {% else %}
@@ -91,9 +91,9 @@ template:
             {{ as_timestamp(state_attr('weather.hourly', 'forecast')[1].datetime) | timestamp_custom('%I') | int }} {{ as_timestamp(state_attr('weather.hourly', 'forecast')[1].datetime) | timestamp_custom('%p') }}
           weather_condition_2: >
             {% set cond2 = state_attr('weather.hourly', 'forecast')[2].condition %}
-            {% set next_setting = as_timestampstate_attr('sun.sun', 'next_setting')) %}
-            {% set next_rising = as_timestampstate_attr('sun.sun', 'next_rising')) %}
-            {% set cond2_time = as_timestampstate_attr('weather.hourly', 'forecast')[2].datetime) %}
+            {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
+            {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
+            {% set cond2_time = as_timestamp(state_attr('weather.hourly', 'forecast')[2].datetime) %}
             {% if cond2_time > next_setting && cond2_time < next_rising %}
                 {% if cond2 == 'sunny' %} night {% elif cond2 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond2 }} {% endif %}
             {% else %}
@@ -105,9 +105,9 @@ template:
             {{ as_timestamp(state_attr('weather.hourly', 'forecast')[2].datetime) | timestamp_custom('%I') | int }} {{ as_timestamp(state_attr('weather.hourly', 'forecast')[2].datetime) | timestamp_custom('%p') }}
           weather_condition_3: >
             {% set cond3 = state_attr('weather.hourly', 'forecast')[3].condition %}
-            {% set next_setting = as_timestampstate_attr('sun.sun', 'next_setting')) %}
-            {% set next_rising = as_timestampstate_attr('sun.sun', 'next_rising')) %}
-            {% set cond3_time = as_timestampstate_attr('weather.hourly', 'forecast')[3]].datetime) %}
+            {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
+            {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
+            {% set cond3_time = as_timestamp(state_attr('weather.hourly', 'forecast')[3]].datetime) %}
             {% if cond3_time > next_setting && cond3_time < next_rising %}
                 {% if cond3 == 'sunny' %} night {% elif cond3 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond3 }} {% endif %}
             {% else %}

--- a/sensor.yaml
+++ b/sensor.yaml
@@ -63,7 +63,10 @@ template:
             {% endif %}
           weather_condition_0: >
             {% set cond0 = state_attr('weather.hourly', 'forecast')[0].condition %}
-            {% if states('sun.sun') == 'below_horizon' %}
+            {% set next_setting = as_timestampstate_attr('sun.sun', 'next_setting')) %}
+            {% set next_rising = as_timestampstate_attr('sun.sun', 'next_rising')) %}
+            {% set cond0_time = as_timestampstate_attr('weather.hourly', 'forecast')[0].datetime) %}
+            {% if cond0_time > next_setting && cond0_time < next_rising %}
                 {% if cond0 == 'sunny' %} night {% elif cond0 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond0 }} {% endif %}
             {% else %}
                 {{ cond0 }}
@@ -74,7 +77,10 @@ template:
             {{ as_timestamp(state_attr('weather.hourly', 'forecast')[0].datetime) | timestamp_custom('%I') | int }} {{ as_timestamp(state_attr('weather.hourly', 'forecast')[0].datetime) | timestamp_custom('%p') }}
           weather_condition_1: >
             {% set cond1 = state_attr('weather.hourly', 'forecast')[1].condition %}
-            {% if states('sun.sun') == 'below_horizon' %}
+            {% set next_setting = as_timestampstate_attr('sun.sun', 'next_setting')) %}
+            {% set next_rising = as_timestampstate_attr('sun.sun', 'next_rising')) %}
+            {% set cond1_time = as_timestampstate_attr('weather.hourly', 'forecast')[1].datetime) %}
+            {% if cond1_time > next_setting && cond1_time < next_rising %}
                 {% if cond1 == 'sunny' %} night {% elif cond1 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond1 }} {% endif %}
             {% else %}
                 {{ cond1 }}
@@ -85,7 +91,10 @@ template:
             {{ as_timestamp(state_attr('weather.hourly', 'forecast')[1].datetime) | timestamp_custom('%I') | int }} {{ as_timestamp(state_attr('weather.hourly', 'forecast')[1].datetime) | timestamp_custom('%p') }}
           weather_condition_2: >
             {% set cond2 = state_attr('weather.hourly', 'forecast')[2].condition %}
-            {% if states('sun.sun') == 'below_horizon' %}
+            {% set next_setting = as_timestampstate_attr('sun.sun', 'next_setting')) %}
+            {% set next_rising = as_timestampstate_attr('sun.sun', 'next_rising')) %}
+            {% set cond2_time = as_timestampstate_attr('weather.hourly', 'forecast')[2].datetime) %}
+            {% if cond2_time > next_setting && cond2_time < next_rising %}
                 {% if cond2 == 'sunny' %} night {% elif cond2 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond2 }} {% endif %}
             {% else %}
                 {{ cond2 }}
@@ -96,7 +105,10 @@ template:
             {{ as_timestamp(state_attr('weather.hourly', 'forecast')[2].datetime) | timestamp_custom('%I') | int }} {{ as_timestamp(state_attr('weather.hourly', 'forecast')[2].datetime) | timestamp_custom('%p') }}
           weather_condition_3: >
             {% set cond3 = state_attr('weather.hourly', 'forecast')[3].condition %}
-            {% if states('sun.sun') == 'below_horizon' %}
+            {% set next_setting = as_timestampstate_attr('sun.sun', 'next_setting')) %}
+            {% set next_rising = as_timestampstate_attr('sun.sun', 'next_rising')) %}
+            {% set cond3_time = as_timestampstate_attr('weather.hourly', 'forecast')[3]].datetime) %}
+            {% if cond3_time > next_setting && cond3_time < next_rising %}
                 {% if cond3 == 'sunny' %} night {% elif cond3 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond3 }} {% endif %}
             {% else %}
                 {{ cond3 }}

--- a/sensor.yaml
+++ b/sensor.yaml
@@ -66,7 +66,7 @@ template:
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
             {% set cond0_time = as_timestamp(state_attr('weather.hourly', 'forecast')[0].datetime) %}
-            {% if cond0_time > next_setting && cond0_time < next_rising %}
+            {% if cond0_time > next_setting and cond0_time < next_rising %}
                 {% if cond0 == 'sunny' %} night {% elif cond0 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond0 }} {% endif %}
             {% else %}
                 {{ cond0 }}
@@ -80,7 +80,7 @@ template:
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
             {% set cond1_time = as_timestamp(state_attr('weather.hourly', 'forecast')[1].datetime) %}
-            {% if cond1_time > next_setting && cond1_time < next_rising %}
+            {% if cond1_time > next_setting and cond1_time < next_rising %}
                 {% if cond1 == 'sunny' %} night {% elif cond1 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond1 }} {% endif %}
             {% else %}
                 {{ cond1 }}
@@ -94,7 +94,7 @@ template:
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
             {% set cond2_time = as_timestamp(state_attr('weather.hourly', 'forecast')[2].datetime) %}
-            {% if cond2_time > next_setting && cond2_time < next_rising %}
+            {% if cond2_time > next_setting and cond2_time < next_rising %}
                 {% if cond2 == 'sunny' %} night {% elif cond2 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond2 }} {% endif %}
             {% else %}
                 {{ cond2 }}
@@ -108,7 +108,7 @@ template:
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
             {% set cond3_time = as_timestamp(state_attr('weather.hourly', 'forecast')[3]].datetime) %}
-            {% if cond3_time > next_setting && cond3_time < next_rising %}
+            {% if cond3_time > next_setting and cond3_time < next_rising %}
                 {% if cond3 == 'sunny' %} night {% elif cond3 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond3 }} {% endif %}
             {% else %}
                 {{ cond3 }}

--- a/sensor.yaml
+++ b/sensor.yaml
@@ -107,7 +107,7 @@ template:
             {% set cond3 = state_attr('weather.hourly', 'forecast')[3].condition %}
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
-            {% set cond3_time = as_timestamp(state_attr('weather.hourly', 'forecast')[3]].datetime) %}
+            {% set cond3_time = as_timestamp(state_attr('weather.hourly', 'forecast')[3].datetime) %}
             {% if cond3_time > next_setting and cond3_time < next_rising %}
                 {% if cond3 == 'sunny' %} night {% elif cond3 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond3 }} {% endif %}
             {% else %}

--- a/sensor.yaml
+++ b/sensor.yaml
@@ -55,27 +55,52 @@ template:
           train_status_canarsie: >
             {{ state_attr('sensor.mta_subway_l_service_status', 'direction_statuses').south | upper }}
           weather_condition_now: >
-            {{ states('weather.hourly') }}
+            {% set cond_now = states('weather.hourly') %}
+            {% if states('sun.sun') == 'below_horizon' %}
+                {% if cond_now == 'sunny' %} night {% elif cond_now == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond_now }} {% endif %}
+            {% else %}
+                {{ cond_now }}
+            {% endif %}
           weather_condition_0: >
-            {{ state_attr('weather.hourly', 'forecast')[0].condition }}
+            {% set cond0 = state_attr('weather.hourly', 'forecast')[0].condition %}
+            {% if states('sun.sun') == 'below_horizon' %}
+                {% if cond0 == 'sunny' %} night {% elif cond0 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond0 }} {% endif %}
+            {% else %}
+                {{ cond0 }}
+            {% endif %}
           weather_temperature_0: >
             {{ state_attr('weather.hourly', 'forecast')[0].temperature | round }}
           weather_timestamp_0: >
             {{ as_timestamp(state_attr('weather.hourly', 'forecast')[0].datetime) | timestamp_custom('%I') | int }} {{ as_timestamp(state_attr('weather.hourly', 'forecast')[0].datetime) | timestamp_custom('%p') }}
           weather_condition_1: >
-            {{ state_attr('weather.hourly', 'forecast')[1].condition }}
+            {% set cond1 = state_attr('weather.hourly', 'forecast')[1].condition %}
+            {% if states('sun.sun') == 'below_horizon' %}
+                {% if cond1 == 'sunny' %} night {% elif cond1 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond1 }} {% endif %}
+            {% else %}
+                {{ cond1 }}
+            {% endif %}
           weather_temperature_1: >
             {{ state_attr('weather.hourly', 'forecast')[1].temperature | round }}
           weather_timestamp_1: >
             {{ as_timestamp(state_attr('weather.hourly', 'forecast')[1].datetime) | timestamp_custom('%I') | int }} {{ as_timestamp(state_attr('weather.hourly', 'forecast')[1].datetime) | timestamp_custom('%p') }}
           weather_condition_2: >
-            {{ state_attr('weather.hourly', 'forecast')[2].condition }}
+            {% set cond2 = state_attr('weather.hourly', 'forecast')[2].condition %}
+            {% if states('sun.sun') == 'below_horizon' %}
+                {% if cond2 == 'sunny' %} night {% elif cond2 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond2 }} {% endif %}
+            {% else %}
+                {{ cond2 }}
+            {% endif %}
           weather_temperature_2: >
             {{ state_attr('weather.hourly', 'forecast')[2].temperature | round }}
           weather_timestamp_2: >
             {{ as_timestamp(state_attr('weather.hourly', 'forecast')[2].datetime) | timestamp_custom('%I') | int }} {{ as_timestamp(state_attr('weather.hourly', 'forecast')[2].datetime) | timestamp_custom('%p') }}
           weather_condition_3: >
-            {{ state_attr('weather.hourly', 'forecast')[3].condition }}
+            {% set cond3 = state_attr('weather.hourly', 'forecast')[3].condition %}
+            {% if states('sun.sun') == 'below_horizon' %}
+                {% if cond3 == 'sunny' %} night {% elif cond3 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond3 }} {% endif %}
+            {% else %}
+                {{ cond3 }}
+            {% endif %}
           weather_temperature_3: >
             {{ state_attr('weather.hourly', 'forecast')[3].temperature | round }}
           weather_timestamp_3: >


### PR DESCRIPTION
With met.no weather feed to Home Assistant - there's no difference in night time weather and daytime - specifically a clear night and partly clear night. 

A Clear sky is classed as a "sunny" state, even at night. I have added some checks in the HA yaml template to check if the Sun sensor (You need Sun in your Home Assistant install) is state = "below_horizon" and update "sunny" and "partlycloudy" to be "night" and "night-partly-cloudy". This then requests icons in the ESPHome yaml to include the Moon - which makes it look right when you are looking at the display at night, or when the upcoming forecast hours are night time - a clear night sky = the Moon, not the Sun.

Or at least it makes more sense in my eyes to see the Moon icons at night that seeing a clear Sunny day predicted for 2AM(!!) :)