### PR TITLE
Correct nigh time symbols when Sun has set

### DIFF
--- a/sensor.yaml
+++ b/sensor.yaml
@@ -68,7 +68,9 @@ template:
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
             {% set cond0_time = as_timestamp(state_attr('weather.hourly', 'forecast')[0].datetime) %}
-            {% if cond0_time > next_setting and cond0_time < next_rising %}
+            {% if states('sun.sun') == 'above_horizon' and cond0_time > next_setting %}
+                {% if cond0 == 'sunny' %} night {% elif cond0 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond0 }} {% endif %}
+            {% elif states('sun.sun') == 'below_horizon' and cond0_time < next_rising %}
                 {% if cond0 == 'sunny' %} night {% elif cond0 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond0 }} {% endif %}
             {% else %}
                 {{ cond0 }}
@@ -83,7 +85,9 @@ template:
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
             {% set cond1_time = as_timestamp(state_attr('weather.hourly', 'forecast')[1].datetime) %}
-            {% if cond1_time > next_setting and cond1_time < next_rising %}
+            {% if states('sun.sun') == 'above_horizon' and cond1_time > next_setting %}
+                {% if cond1 == 'sunny' %} night {% elif cond1 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond1 }} {% endif %}
+            {% elif states('sun.sun') == 'below_horizon' and cond1_time < next_rising %}
                 {% if cond1 == 'sunny' %} night {% elif cond1 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond1 }} {% endif %}
             {% else %}
                 {{ cond1 }}
@@ -98,7 +102,9 @@ template:
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
             {% set cond2_time = as_timestamp(state_attr('weather.hourly', 'forecast')[2].datetime) %}
-            {% if cond2_time > next_setting and cond2_time < next_rising %}
+            {% if states('sun.sun') == 'above_horizon' and cond2_time > next_setting %}
+                {% if cond2 == 'sunny' %} night {% elif cond2 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond2 }} {% endif %}
+            {% elif states('sun.sun') == 'below_horizon' and cond2_time < next_rising %}
                 {% if cond2 == 'sunny' %} night {% elif cond2 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond2 }} {% endif %}
             {% else %}
                 {{ cond2 }}
@@ -113,7 +119,9 @@ template:
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
             {% set cond3_time = as_timestamp(state_attr('weather.hourly', 'forecast')[3].datetime) %}
-            {% if cond3_time > next_setting and cond3_time < next_rising %}
+            {% if states('sun.sun') == 'above_horizon' and cond3_time > next_setting %}
+                {% if cond3 == 'sunny' %} night {% elif cond3 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond3 }} {% endif %}
+            {% elif states('sun.sun') == 'below_horizon' and cond3_time < next_rising %}
                 {% if cond3 == 'sunny' %} night {% elif cond3 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond3 }} {% endif %}
             {% else %}
                 {{ cond3 }}


### PR DESCRIPTION
I didn't notice a bug in my nigh time symbol check to make the Moon symbols appear after Sun set. Turns out when the Sun has set, the original code was checking the setting of the FOLLOWING day, so the condition was never met, so night time symbols during night were reverting to day time. 

This update checks if Sun has set or not, and checks for appropriate rising or setting times depending if Sun has set or not.

(future update would be to swap out Sun rising and setting times with Sun dusk and dawn times, as a bright Sun icon for 8pm (here in UK in summer) looks odd when it is getting dark, meh, maybe?!  ¯\\_(ツ)_/¯