### PR TITLE
Fixes day/night detection and an indentation bug

### DIFF
--- a/sensor.yaml
+++ b/sensor.yaml
@@ -84,7 +84,7 @@ template:
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
             {% set cond0_time = as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[0].datetime) %}
-            {% if cond0_time > next_setting and cond0_time < next_rising %}
+            {% if cond0_time < next_rising and next_rising < next_setting %}
                 {% if cond0 == 'sunny' %} night {% elif cond0 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond0 }} {% endif %}
             {% else %}
                 {{ cond0 }}
@@ -99,7 +99,7 @@ template:
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
             {% set cond1_time = as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[1].datetime) %}
-            {% if cond1_time > next_setting and cond1_time < next_rising %}
+            {% if cond1_time < next_rising and next_rising < next_setting %}
                 {% if cond1 == 'sunny' %} night {% elif cond1 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond1 }} {% endif %}
             {% else %}
                 {{ cond1 }}
@@ -114,7 +114,7 @@ template:
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
             {% set cond2_time = as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[2].datetime) %}
-            {% if cond2_time > next_setting and cond2_time < next_rising %}
+            {% if cond2_time < next_rising and next_rising < next_setting %}
                 {% if cond2 == 'sunny' %} night {% elif cond2 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond2 }} {% endif %}
             {% else %}
                 {{ cond2 }}
@@ -129,7 +129,7 @@ template:
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
             {% set cond3_time = as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[3].datetime) %}
-            {% if cond3_time > next_setting and cond3_time < next_rising %}
+            {% if cond3_time < next_rising and next_rising < next_setting %}
                 {% if cond3 == 'sunny' %} night {% elif cond3 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond3 }} {% endif %}
             {% else %}
                 {{ cond3 }}

--- a/weatherman.yaml
+++ b/weatherman.yaml
@@ -54,9 +54,9 @@ time:
                       binary_sensor.is_on: motion_detected
                     then:
                       - logger.log: "Sensor data updated and activity in home detected: Refreshing display..."
-                - component.update: eink_display
-                - lambda: 'id(data_updated) = false;'
-              else:
+                      - component.update: eink_display
+                      - lambda: 'id(data_updated) = false;'
+                    else:
                       - logger.log: "Sensor data updated but no activity in home - skipping display refresh."
               else:
                 - logger.log: "No sensors updated - skipping display refresh."


### PR DESCRIPTION
Day/night detection is used in sensor.yaml to select the appropriate weather icon (e.g. 'sunny' vs 'night'). The previous if condition did not work for the weather_condition_x states, when the _now state was in a different part of the day/night cycle.
This commit should fix this issue, as long as weather_condition_x is not too far in the future (not more than one day or night phase).

Additional bug fix:
- fix an indentation bug in weatherman.yaml