### PR TITLE
Update sensor.yaml - for new Weather Forecast Service

### DIFF
--- a/sensor.yaml
+++ b/sensor.yaml
@@ -60,6 +60,13 @@ template:
   - trigger:
       platform: time_pattern
       minutes: "/1"
+    action:
+      - service: weather.get_forecast
+        target:
+          entity_id: weather.valhalla
+        data:
+          type: hourly
+        response_variable: weather_valhalla_hourly  
     sensor:
       - name: Weatherman Data
         state: "OK"
@@ -72,7 +79,7 @@ template:
             {{ state_attr('sensor.mta_subway_l_service_status', 'direction_statuses').south | upper }}
 
           weather_condition_now: >
-            {% set cond_now = states('weather.valhalla_hourly') %}
+            {% set cond_now = states('weather.valhalla') %}
             {% if states('sun.sun') == 'below_horizon' %}
                 {% if cond_now == 'sunny' %} night {% elif cond_now == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond_now }} {% endif %}
             {% else %}
@@ -80,61 +87,61 @@ template:
             {% endif %}
 
           weather_condition_0: >
-            {% set cond0 = state_attr('weather.valhalla_hourly', 'forecast')[0].condition %}
+            {% set cond0 = weather_valhalla_hourly.forecast[0].condition %}
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
-            {% set cond0_time = as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[0].datetime) %}
+            {% set cond0_time = as_timestamp(weather_valhalla_hourly.forecast[0].datetime) %}
             {% if cond0_time < next_rising and next_rising < next_setting %}
                 {% if cond0 == 'sunny' %} night {% elif cond0 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond0 }} {% endif %}
             {% else %}
                 {{ cond0 }}
             {% endif %}
           weather_temperature_0: >
-            {{ state_attr('weather.valhalla_hourly', 'forecast')[0].temperature | round }}
+            {{ weather_valhalla_hourly.forecast[0].temperature | round }}
           weather_timestamp_0: >
-            {{ as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[0].datetime) | timestamp_custom('%I') | int }} {{ as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[0].datetime) | timestamp_custom('%p') }}
+            {{ as_timestamp(weather_valhalla_hourly.forecast[0].datetime) | timestamp_custom('%I') | int }} {{ as_timestamp(weather_valhalla_hourly.forecast[0].datetime) | timestamp_custom('%p') }}
 
           weather_condition_1: >
-            {% set cond1 = state_attr('weather.valhalla_hourly', 'forecast')[1].condition %}
+            {% set cond1 = weather_valhalla_hourly.forecast[1].condition %}
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
-            {% set cond1_time = as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[1].datetime) %}
+            {% set cond1_time = as_timestamp(weather_valhalla_hourly.forecast[1].datetime) %}
             {% if cond1_time < next_rising and next_rising < next_setting %}
                 {% if cond1 == 'sunny' %} night {% elif cond1 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond1 }} {% endif %}
             {% else %}
                 {{ cond1 }}
             {% endif %}
           weather_temperature_1: >
-            {{ state_attr('weather.valhalla_hourly', 'forecast')[1].temperature | round }}
+            {{ weather_valhalla_hourly.forecast[1].temperature | round }}
           weather_timestamp_1: >
-            {{ as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[1].datetime) | timestamp_custom('%I') | int }} {{ as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[1].datetime) | timestamp_custom('%p') }}
+            {{ as_timestamp(weather_valhalla_hourly.forecast[1].datetime) | timestamp_custom('%I') | int }} {{ as_timestamp(weather_valhalla_hourly.forecast[1].datetime) | timestamp_custom('%p') }}
 
           weather_condition_2: >
-            {% set cond2 = state_attr('weather.valhalla_hourly', 'forecast')[2].condition %}
+            {% set cond2 = weather_valhalla_hourly.forecast[2].condition %}
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
-            {% set cond2_time = as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[2].datetime) %}
+            {% set cond2_time = as_timestamp(weather_valhalla_hourly.forecast[2].datetime) %}
             {% if cond2_time < next_rising and next_rising < next_setting %}
                 {% if cond2 == 'sunny' %} night {% elif cond2 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond2 }} {% endif %}
             {% else %}
                 {{ cond2 }}
             {% endif %}
           weather_temperature_2: >
-            {{ state_attr('weather.valhalla_hourly', 'forecast')[2].temperature | round }}
+            {{ weather_valhalla_hourly.forecast[2].temperature | round }}
           weather_timestamp_2: >
-            {{ as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[2].datetime) | timestamp_custom('%I') | int }} {{ as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[2].datetime) | timestamp_custom('%p') }}
+            {{ as_timestamp(weather_valhalla_hourly.forecast[2].datetime) | timestamp_custom('%I') | int }} {{ as_timestamp(weather_valhalla_hourly.forecast[2].datetime) | timestamp_custom('%p') }}
 
           weather_condition_3: >
-            {% set cond3 = state_attr('weather.valhalla_hourly', 'forecast')[3].condition %}
+            {% set cond3 = weather_valhalla_hourly.forecast[3].condition %}
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
-            {% set cond3_time = as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[3].datetime) %}
+            {% set cond3_time = as_timestamp(weather_valhalla_hourly.forecast[3].datetime) %}
             {% if cond3_time < next_rising and next_rising < next_setting %}
                 {% if cond3 == 'sunny' %} night {% elif cond3 == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond3 }} {% endif %}
             {% else %}
                 {{ cond3 }}
             {% endif %}
           weather_temperature_3: >
-            {{ state_attr('weather.valhalla_hourly', 'forecast')[3].temperature | round }}
+            {{ weather_valhalla_hourly.forecast[3].temperature | round }}
           weather_timestamp_3: >
-            {{ as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[3].datetime) | timestamp_custom('%I') | int }} {{ as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[3].datetime) | timestamp_custom('%p') }}
+            {{ as_timestamp(weather_valhalla_hourly.forecast[3].datetime) | timestamp_custom('%I') | int }} {{ as_timestamp(weather_valhalla_hourly.forecast[3].datetime) | timestamp_custom('%p') }}


### PR DESCRIPTION
With the new HA Weather Forecast service to get the weather, Met.no no longer has the option for an "hourly" entity. new users of this sensor and project won't be able to get the Met.no Hourly entity.

This update adds in the "service: weather.get_forecast" call to get the hourly result. This is then added to the sensor using variable "weather_valhalla_hourly".

It assumes your met.no weather entity is called "weather.valhalla" - adjust accordingly in the action entity_id.