### PR TITLE
Update sensor.yaml - Correcting for partlyclouded and night

### DIFF
--- a/sensor.yaml
+++ b/sensor.yaml
@@ -73,6 +73,8 @@ template:
 
           weather_condition_now: >
             {% set cond_now = states('weather.valhalla_hourly') %}
+            {% if cond_now == 'partlycloudy' %}{% set cond_now = 'partly-cloudy' %}{% endif %}
+            {% if cond_now == 'clear-night' %}{% set cond_now = 'night' %}{% endif %}
             {% if states('sun.sun') == 'below_horizon' %}
                 {% if cond_now == 'sunny' %} night {% elif cond_now == 'partlycloudy' %} night-partly-cloudy {% else %} {{ cond_now }} {% endif %}
             {% else %}
@@ -81,6 +83,8 @@ template:
 
           weather_condition_0: >
             {% set cond0 = state_attr('weather.valhalla_hourly', 'forecast')[0].condition %}
+            {% if cond0 == 'partlycloudy' %}{% set cond0 = 'partly-cloudy' %}{% endif %}
+            {% if cond0 == 'clear-night' %}{% set cond0 = 'night' %}{% endif %}
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
             {% set cond0_time = as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[0].datetime) %}
@@ -96,6 +100,8 @@ template:
 
           weather_condition_1: >
             {% set cond1 = state_attr('weather.valhalla_hourly', 'forecast')[1].condition %}
+            {% if cond1 == 'partlycloudy' %}{% set cond1 = 'partly-cloudy' %}{% endif %}
+            {% if cond1 == 'clear-night' %}{% set cond1 = 'night' %}{% endif %}
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
             {% set cond1_time = as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[1].datetime) %}
@@ -111,6 +117,8 @@ template:
 
           weather_condition_2: >
             {% set cond2 = state_attr('weather.valhalla_hourly', 'forecast')[2].condition %}
+            {% if cond2 == 'partlycloudy' %}{% set cond2 = 'partly-cloudy' %}{% endif %}
+            {% if cond2 == 'clear-night' %}{% set cond2 = 'night' %}{% endif %}
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
             {% set cond2_time = as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[2].datetime) %}
@@ -126,6 +134,8 @@ template:
 
           weather_condition_3: >
             {% set cond3 = state_attr('weather.valhalla_hourly', 'forecast')[3].condition %}
+            {% if cond3 == 'partlycloudy' %}{% set cond3 = 'partly-cloudy' %}{% endif %}
+            {% if cond3 == 'clear-night' %}{% set cond3 = 'night' %}{% endif %}
             {% set next_setting = as_timestamp(state_attr('sun.sun', 'next_setting')) %}
             {% set next_rising = as_timestamp(state_attr('sun.sun', 'next_rising')) %}
             {% set cond3_time = as_timestamp(state_attr('weather.valhalla_hourly', 'forecast')[3].datetime) %}


### PR DESCRIPTION
Updates to condition value for 'partlycloudy' to be set to 'partly-cloudy' for MDI icons to work, and the new met.no integration checks for night time clear weather now using sun.down, so need to check 'clear-night' to 'night', as MDI does not have clear-night icon.