### PR TITLE
Invert busy pin to prevent display damage

### DIFF
--- a/weatherman.yaml
+++ b/weatherman.yaml
@@ -438,7 +438,9 @@ display:
     id: eink_display
     cs_pin: GPIO15
     dc_pin: GPIO27
-    busy_pin: GPIO25
+    busy_pin:
+      number: GPIO25
+      inverted: true
     reset_pin: GPIO26
     reset_duration: 2ms
     model: 7.50inV2


### PR DESCRIPTION
As per the documentation `Waveshare 7.50in V2 models must be inverted to prevent permanent display damage`

See the documentation for the waveshare_epaper platform and github issue where this was first raised below: 
https://esphome.io/components/display/waveshare_epaper.html#configuration-variables
https://github.com/esphome/issues/issues/4739